### PR TITLE
Fixed handling of cardinality fields in index parser

### DIFF
--- a/tableparser/tableparser.go
+++ b/tableparser/tableparser.go
@@ -32,7 +32,7 @@ type IndexField struct {
 	SeqInIndex   int
 	ColumnName   string
 	Collation    sql.NullString
-	Cardinality  int
+	Cardinality  sql.NullInt64
 	SubPart      sql.NullInt64
 	Packed       sql.NullString
 	Null         string


### PR DESCRIPTION
Fixes issues when storage engine shows index cardinality as null:

```
2017/12/12 14:25:24 cannot get table namespace struct: cannot read indexes: sql: Scan error on column index 6: converting driver.Value type <nil> ("<nil>") to a int: invalid syntax
```
